### PR TITLE
fix(package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "ioredis": "^3.2.1",
     "lodash": "^4.17.4",
     "mongoose": "4.9.9",
-    "mongoose-validators": "0.1.0",
     "node-restify-validation": "^1.1.1",
     "peanut-restify-jwt": "0.4.4",
     "restify": "^5.2.0",


### PR DESCRIPTION
Removed mongoose-validators. This library is not used and has a high vulnerability